### PR TITLE
Add Bourne-style shell compliance for var names

### DIFF
--- a/twitch/twitch.go
+++ b/twitch/twitch.go
@@ -32,7 +32,7 @@ type Client struct {
 func NewClient(httpClient *http.Client) *Client {
 	baseURL, _ := url.Parse(rootURL)
 
-	clientId := os.Getenv("GO-TWITCH_CLIENTID")
+	clientId := os.Getenv("GO_TWITCH_CLIENTID")
 	c := &Client{client: httpClient, BaseURL: baseURL, ClientId: clientId}
 	c.Channels = &ChannelsMethod{client: c}
 	c.Chat = &ChatMethod{client: c}


### PR DESCRIPTION
I can't configure my Client ID as a shell environment variable because zsh/bash don't like it. I've resolved the issue by fixing the expected variable name with something that is compliant with Bourne-style shells.

http://unix.stackexchange.com/questions/23659/can-shell-variable-include-character
